### PR TITLE
refactor. 영수증 검증/저장 로직 개선

### DIFF
--- a/src/main/java/com/ssginc/unnie/common/util/ErrorCode.java
+++ b/src/main/java/com/ssginc/unnie/common/util/ErrorCode.java
@@ -100,8 +100,8 @@ public enum ErrorCode {
     REVIEW_FILE_EXCEEDED(400, "RV005", "최대 5장의 이미지를 첨부할 수 있습니다."),
     INVALID_REVIEW_CONTENT(400, "RV006", "리뷰 내용이 형식에 맞지 않습니다."),
     REVIEW_LENGTH_EXCEEDED(400, "RV007", "리뷰 길이가 제한을 초과했습니다."),
-    DUPLICATE_REVIEW(400, "RV008", "동일한 리뷰를 중복 작성할 수 없습니다."),
-    EXPIRED_RECEIPT(400, "RV009", "영수증 사용 기한이 만료되었습니다."),
+    DUPLICATE_REVIEW(409, "RV008", "동일한 리뷰를 중복 작성할 수 없습니다."),
+    EXPIRED_RECEIPT(400, "RV009", "리뷰 작성 가능한 영수증의 기한이 만료되었습니다."),
     INVALID_RECEIPT(400, "RV010", "유효하지 않은 영수증입니다."),
     OCR_PROCESSING_FAILED(400, "RV011", "OCR 분석 중 오류가 발생했습니다."),
     INVALID_AI_SUMMARY(400, "RV012", "리뷰 요약 중 오류가 발생했습니다."),
@@ -118,6 +118,13 @@ public enum ErrorCode {
     REVIEW_SEARCH_FAILED(500, "RV023", "리뷰를 가져오는 중 오류가 발생했습니다."),
     REVIEW_RATE_REQUIRED(400, "RV024", "리뷰 별점은 필수 입력 항목입니다."),
     REVIEW_RATE_EXCEEDED(400, "RV025", "리뷰 별점은 최대 5개까지 입력 가능합니다."),
+    DUPLICATE_RECEIPT(409, "RV026", "이미 인증된 영수증입니다."),
+    KEYWORDS_DELETE_FAILED(404, "RV027", "키워드 삭제에 실패하였습니다."),
+    INVALID_RECEIPT_APPROVALNumber(400, "RV028", "유효하지 않은 승인번호입니다."),
+    RECEIPT_SAVE_FAILED(500, "RV029", "영수증 저장에 실패했습니다."),
+    REVIEW_CREATE_FAILED(500, "RV030", "리뷰 작성에 실패했습니다."),
+    INVALID_REVIEW_AUTHOR(400, "RV031", "리뷰 작성자가 다릅니다."),
+
 
     // =================================== 게시글 관련 에러 =====================================================
     BOARD_CATEGORY_REQUIRED(400, "BO001", "게시글 카테고리는 필수 입력 항목입니다."),

--- a/src/main/java/com/ssginc/unnie/common/util/validation/ReviewValidator.java
+++ b/src/main/java/com/ssginc/unnie/common/util/validation/ReviewValidator.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Component
 public class ReviewValidator implements Validator<ReviewRequestBase> {
 
-    private static final int MIN_REVIEW_LENGTH = 10;
+    private static final int MIN_REVIEW_LENGTH = 1;
     private static final int MAX_REVIEW_LENGTH = 400;
     private static final int MIN_RATING = 1;
     private static final int MAX_RATING = 5;

--- a/src/main/java/com/ssginc/unnie/review/controller/ReceiptController.java
+++ b/src/main/java/com/ssginc/unnie/review/controller/ReceiptController.java
@@ -30,25 +30,15 @@ public class ReceiptController {
      */
     @PostMapping("/save")
     public ResponseEntity<ResponseDto<ReceiptResponse>> saveReceipt
-                                        (@RequestBody ReceiptRequest receiptRequest) {
-        log.info("영수증 데이터: {}", receiptRequest); // 여기서 데이터가 잘 들어오는지 로그 확인 필수!
+    (@RequestBody ReceiptRequest receiptRequest) {
+        log.info("영수증 데이터: {}", receiptRequest); //데이터가 잘 들어오는지 로그 확인
 
-        try {
-            if (!receiptSaveValidator.validate(receiptRequest)) {
-                return ResponseEntity.badRequest()
-                        .body(new ResponseDto<>(HttpStatus.BAD_REQUEST.value(), "필수 데이터가 누락되었습니다.", null));
-            }
+        ReceiptResponse savedReceipt = receiptService.saveReceipt(receiptRequest);
 
-            ReceiptResponse savedReceipt = receiptService.saveReceipt(receiptRequest);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(new ResponseDto<>(HttpStatus.CREATED.value(), "저장 성공", savedReceipt));
-
-        } catch (Exception e) {
-            log.error("저장 중 에러 발생: ", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ResponseDto<>(500, "서버 오류: " + e.getMessage(), null));
-        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ResponseDto<>(HttpStatus.CREATED.value(), "저장 성공", savedReceipt));
     }
+
 
     /**
      * 특정 영수증 조회

--- a/src/main/java/com/ssginc/unnie/review/controller/ReviewController.java
+++ b/src/main/java/com/ssginc/unnie/review/controller/ReviewController.java
@@ -42,16 +42,21 @@ public class ReviewController {
      * JWT 토큰을 통해 인증된 회원의 memberId를 ReviewCreateRequest에 세팅합니다.
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResponseDto<Map<String, String>>> createReview(@AuthenticationPrincipal MemberPrincipal memberPrincipal, @ModelAttribute ReviewCreateRequest reviewCreateRequest, @RequestParam("keywordId") String keywordId) {
+    public ResponseEntity<ResponseDto<Map<String, String>>> createReview(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @ModelAttribute ReviewCreateRequest reviewCreateRequest,
+            @RequestParam("keywordId") String keywordId) {
 
-        // 1️⃣ 로그인 체크
+        // 1. 로그인 체크
         if (memberPrincipal == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
 
-        // 2️⃣ 영수증 리뷰 가능 여부 체크
+        // 2. 영수증 리뷰 가능 여부 체크
         ReceiptForReviewContext receiptContext =
-                receiptVerificationService.verifyForReview(reviewCreateRequest.getReviewReceiptId());
+                receiptVerificationService.verifyForReview(
+                        reviewCreateRequest.getReviewReceiptId()
+                );
 
         // shopId 확보 (이벤트용)
         long shopId = receiptContext.getShopId();
@@ -72,7 +77,15 @@ public class ReviewController {
         // 6. 리뷰 생성
         long reviewId = reviewService.createReview(reviewCreateRequest);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseDto<>(HttpStatus.CREATED.value(), "리뷰 작성에 성공했습니다.", Map.of("reviewId", String.valueOf(reviewId))));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ResponseDto<>(
+                        HttpStatus.CREATED.value(),
+                        "리뷰 작성에 성공했습니다.",
+                        Map.of(
+                                "reviewId", String.valueOf(reviewId),
+                                "shopId", String.valueOf(shopId)
+                        )
+                ));
     }
 
 
@@ -121,7 +134,7 @@ public class ReviewController {
 
     /**
      * 리뷰 수정
-     * JWT 토큰에서 추출한 memberId를 DTO에 세팅하여, 소유자 확인 후 수정합니다.
+     * 소유자 확인 후 리뷰 수정
      */
     @PutMapping("/{reviewId}")
     public ResponseEntity<ResponseDto<Map<String, String>>> updateReview(@PathVariable("reviewId") long reviewId, @AuthenticationPrincipal MemberPrincipal memberPrincipal, @RequestBody ReviewUpdateRequest reviewUpdateRequest, @RequestParam(value = "keywordId", required = false) String keywordId) {
@@ -232,7 +245,7 @@ public class ReviewController {
     }
 
     /**
-     * 업체 리뷰 개수 조회 REST API
+     * 업체 리뷰 개수 조회
      *
      * @param shopId  업체 ID (경로 변수)
      * @param keyword 필터링할 키워드 (없으면 빈 문자열)

--- a/src/main/java/com/ssginc/unnie/review/service/serviceImpl/ReceiptVerificationServiceImpl.java
+++ b/src/main/java/com/ssginc/unnie/review/service/serviceImpl/ReceiptVerificationServiceImpl.java
@@ -32,7 +32,7 @@ public class ReceiptVerificationServiceImpl implements ReceiptVerificationServic
         // 승인번호 검증
         if (receipt.getReceiptApprovalNumber() == null ||
                 receipt.getReceiptApprovalNumber().equals("데이터 없음")) {
-            throw new UnnieReviewException(ErrorCode.INVALID_RECEIPT);
+            throw new UnnieReviewException(ErrorCode.INVALID_RECEIPT_APPROVALNumber);
         }
 
         // 30일 이내

--- a/src/main/resources/static/js/review/ocr.js
+++ b/src/main/resources/static/js/review/ocr.js
@@ -31,33 +31,6 @@ document.getElementById("ocrForm").addEventListener("submit", async (e) => {
 
         let extracted = {};
 
-        // ===== 기존 코드 (문제 있는 부분) =====
-        // confirmedData.forEach(field => {
-        //     switch(field.type) {
-        //         case 'SHOP_NAME':
-        //             extracted.shopName = field.value;
-        //             document.getElementById("shopName").value = field.value;
-        //             break;
-        //         case 'AMOUNT':
-        //             extracted.amount = field.value;
-        //             document.getElementById("totalAmount").value = field.value;
-        //             break;
-        //         case 'DATE_TIME':
-        //             extracted.dateTime = field.value;
-        //             document.getElementById("paymentDate").value = field.value;
-        //             break;
-        //         case 'BUSINESS_NUMBER':
-        //             extracted.businessNumber = field.value;
-        //             document.getElementById("businessNumber").value = field.value;
-        //             break;
-        //         case 'APPROVAL_NUMBER':
-        //             extracted.approvalNumber = field.value;
-        //             document.getElementById("approvalNumber").value = field.value;
-        //             break;
-        //     }
-        // });
-
-        // ===== 수정 코드 (구조 안전 + 디버깅 포함) =====
         confirmedData.forEach(field => {
             console.log("OCR field raw:", field);
 
@@ -158,12 +131,25 @@ document.getElementById("saveReceipt").addEventListener("click", async () => {
         });
 
         const saveResult = await response.json();
-        if (response.ok) {
-            alert("영수증 인증이 완료되었습니다.");
-            window.location.href = `/review/create?receiptId=${saveResult.data.receiptId}`;
+        // 실패 케이스
+        //영수증 중복 예외처리
+        if (!response.ok) {
+            if (saveResult.code === 'RV026') {
+                alert('이미 리뷰가 작성된 영수증입니다.');
+                return;
+            }
+
+            alert(saveResult.message || '영수증 저장에 실패했습니다.');
+            return;
         }
+
+        // 성공 케이스
+        alert("영수증 인증이 완료되었습니다.");
+        window.location.href = `/review/create?receiptId=${saveResult.data.receiptId}`;
 
     } catch (error) {
         console.error("저장 실패:", error);
+        alert("서버 통신 중 오류가 발생했습니다.");
     }
+
 });


### PR DESCRIPTION
## 작업 소개
<!-- 작업한 내용을 소개해주세요. -->

- DB Unique Key 제약조건을 통해
  동일 영수증의 중복 저장을 DB 레벨에서 방지

- 영수증 중복 저장 시
  DataIntegrityViolationException을 잡아
  DUPLICATE_RECEIPT(409) 비즈니스 예외로 변환

- 중복 리뷰 시나리오에 대한 예외 코드 정의 및
  클라이언트에서 사용자 친화적인 Alert 처리 추가

- 리뷰 생성 API 응답에 shopId 포함하여
  리뷰 작성 완료 후 해당 업체 리뷰 목록 페이지로 리다이렉트 처리
***
## 기타 사항
<!-- 추가로 전할 말을 작성해주세요. -->

***
## 관련 Issue
<!-- 관련된 이슈를 닫아주세요. ex) closed #1 -->


